### PR TITLE
fix: restrict an else statement to elseif

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -1037,17 +1037,17 @@ function cast_spells()
 			if contains(Spellups["EX"]["noAuto"],i) == false then
 
 				if i == 518 then
-                              if Spellups["NA"][552] == 1 then --if not affected by gaias focus
+					if Spellups["NA"][552] == 1 then --if not affected by gaias focus
 						cast_this(552,tonumber(Spellups["AS"]["list"][552]["type"]))
 						cast_this(518,tonumber(Spellups["AS"]["list"][518]["type"]))
 						hadarprint("Report NA: "..Spellups["NA"][552],"debug")
-                              	hadarprint("Sending "..Spellups["AS"]["list"][552]["name"].." to cast","debug")                                     
-                              else
+						hadarprint("Sending "..Spellups["AS"]["list"][552]["name"].." to cast","debug")
+					else
 						cast_this(518,tonumber(Spellups["AS"]["list"][518]["type"]))
 						hadarprint("Gaias focus reported ON, not casting this time","debug") --why reported on '0' when it was off?
 						hadarprint("Report NA: "..Spellups["NA"][552],"debug")
-                              end
-					return
+					end
+				return
 
 				elseif i == 552 then
 					Spellups["QS"][i] = nil --remove from queue, cannot cast alone

--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -1042,7 +1042,7 @@ function cast_spells()
 						cast_this(518,tonumber(Spellups["AS"]["list"][518]["type"]))
 						hadarprint("Report NA: "..Spellups["NA"][552],"debug")
 						hadarprint("Sending "..Spellups["AS"]["list"][552]["name"].." to cast","debug")
-					else
+					elseif Spellups["NA"][552] == 0 then -- player is affected by gaias focus
 						cast_this(518,tonumber(Spellups["AS"]["list"][518]["type"]))
 						hadarprint("Gaias focus reported ON, not casting this time","debug") --why reported on '0' when it was off?
 						hadarprint("Report NA: "..Spellups["NA"][552],"debug")


### PR DESCRIPTION
the check in cast_spells for gaia's revenge (sp 518) was checking if the player was affected by gaia's focus (sp: 552)

the check was not specifically testing against affected vs not-affected and the loose else statement catches a error condition if the player doesn't have a focus selected.
