### PR TITLE
1.61

### DIFF
--- a/GroupManager/ChangeLog.txt
+++ b/GroupManager/ChangeLog.txt
@@ -1,5 +1,9 @@
 Hadar's Group Manager
 
+V1.61
+June 2 2023
+-Fixed the blank lines from each tell, only added them to the messages with the "passphrase" to join the group
+
 V1.60
 May 31 2023
 -function cani had no leader bypass, so if a command was trusted and leader sent it, it would fail, fixed!

--- a/GroupManager/Hadars_Group_Manager.xml
+++ b/GroupManager/Hadars_Group_Manager.xml
@@ -11,7 +11,7 @@
    save_state="y"
    date_written="2020-01-01 00:00:00"
    requires="4.00"
-   version="1.60"
+   version="1.61"
    >
 
 </plugin>
@@ -407,7 +407,6 @@ function OnPluginBroadcast (msg, id, name, text)
                     local playerName = strip_colours(gmcp("comm.channel.player"))
                     --local _, message = string.match(msg, "^(.+) tells you \'(.*)'$")
                     local message = string.split(msg, ' tells you ', false, 1)
-                    hgmrefresh()
                     hgmTellMessage(playerName,message[2])
                end
 		end
@@ -425,6 +424,10 @@ function hgmTellMessage(p,m)
      
      if args == "" or args == " " then
           args = nil
+     end
+
+     if command == HGMVariable["GL"]["Phrase"] then
+          hgmrefresh()
      end
      
      if command == HGMVariable["GL"]["Phrase"] and HGMVariable["GL"]["Leader"] == "" then


### PR DESCRIPTION
fixed a blank line send on every message, moved to only messages with the passphrase