### PR TITLE
Fix Priest party-sanc gate reading char.base.tier twice

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -1148,7 +1148,7 @@ function affoff(name,line,wc)
 
 	local subclass = gmcp("char.base.subclass")
 	local playerTier = tonumber(gmcp("char.base.tier")) or -1
-	local playerLevel = tonumber(gmcp("char.base.tier")) or -1
+	local playerLevel = tonumber(gmcp("char.base.level")) or -1
 	local totalLevel = tonumber(playerLevel+playerTier)
 
 	if subclass == "Priest" then --make a subclass exception for falling sanc


### PR DESCRIPTION
## Summary

In `SpellupRecast/Hadar_Spellups.xml`, the `affoff()` function has logic that recasts party sanctuary instead of plain sanctuary for high-level Priests when Sanctuary (sn 71) wears off. The gate that enables that path computes `totalLevel = playerLevel + playerTier` and checks `totalLevel >= 121`.

`playerLevel` was being read from `char.base.tier` instead of `char.base.level`, so `totalLevel` was effectively `tier + tier`. That is always far below 121 for any reasonable character, which made the entire Priest party-sanc branch dead code in practice — plain sanctuary would be recast instead of party sanctuary regardless of the player's level.

This one-line change reads `char.base.level` for `playerLevel` so the gate behaves as the surrounding code clearly intends.

### Before
```lua
local playerTier  = tonumber(gmcp("char.base.tier")) or -1
local playerLevel = tonumber(gmcp("char.base.tier")) or -1   -- bug: same field
local totalLevel  = tonumber(playerLevel + playerTier)
```

### After
```lua
local playerTier  = tonumber(gmcp("char.base.tier")) or -1
local playerLevel = tonumber(gmcp("char.base.level")) or -1
local totalLevel  = tonumber(playerLevel + playerTier)
```

## Test plan

- [x] As a subclass-Priest with `level + tier >= 121`, let plain Sanctuary (sn 71) drop and confirm the plugin sends `cast 'party sanctuary'` (verified live in MUSHclient).
- [x] Confirm the fix does not affect non-Priest casts or Priests below the threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)