### PR TITLE
Remove dead autoaura branch in sfail fl==6 handler

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -1258,12 +1258,6 @@ function sfail(name,line,wc)
         return
     end
 	
-	if fl == 6 then
-		if Spellups["GL"]["autoaura"] == 1 then
-			--setup auto aura stuff here
-		end
-	end
-	
 	if fl == 1 or fl == 6 then
 		hadarprint("FL 1 or 6!","debug")
 		if sn == 414 then -- check if party sanctuary failed we are going to just do the recast here


### PR DESCRIPTION
## Summary

In `SpellupRecast/Hadar_Spellups.xml`, the `sfail()` function had a `fl == 6` block containing a nested `if Spellups["GL"]["autoaura"] == 1 then` with an empty body and a `--setup auto aura stuff here` placeholder comment. The `autoaura` flag is stored and compared as the string `"yes"`/`"no"` everywhere else in the plugin (e.g. the `autoaura == "yes"` check in `affoff`), so the `== 1` comparison could never succeed. The body was empty regardless, so the whole nested block was a no-op.

The actual `fl == 6` handling lives in the next conditional, `if fl == 1 or fl == 6 then`, which is unchanged by this PR.

### Before
```lua
if fl == 6 then
    if Spellups["GL"]["autoaura"] == 1 then
        --setup auto aura stuff here
    end
end

if fl == 1 or fl == 6 then
    ...
end
```

### After
```lua
if fl == 1 or fl == 6 then
    ...
end
```

## Test plan

- [x] Pure dead-code removal — empty branch, never-true comparison. No runtime behavior change to test.
- [x] Confirmed by grep that `autoaura` is compared as a string ("yes"/"no") everywhere else; no caller depends on the deleted block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)