### PR TITLE
Clarify wraithform skip-branch comment in affoff

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -1131,7 +1131,7 @@ function affoff(name,line,wc)
 		for i,v in pairs(Spellups["EX"]["wraithform"]) do
 
 			if table.find(v,Spellups["AF"]["list"]) then
-				--left empty becaue
+				-- spell v is still active on the player; no need to requeue
 			else
 				local ctype = tonumber(Spellups["AS"]["list"][v]["type"])
 				Spellups["QS"][v] = Spellups["AS"]["list"][v]["name"]


### PR DESCRIPTION
## Summary

In `SpellupRecast/Hadar_Spellups.xml`, the `affoff()` function has a loop that runs when wraithform (sn 180) drops. The loop iterates over `Spellups["EX"]["wraithform"]` and, for each related spell, checks `table.find(v, Spellups["AF"]["list"])` — a truthy result means the player is currently affected by spell `v`. In that case the branch is intentionally a no-op (spell is still active, nothing to requeue); the `else` branch queues and recasts.

The original placeholder comment was `--left empty becaue` (typo, no explanation), which doesn't tell a reader why the branch is empty. This PR replaces it with a one-line comment describing the intent.

### Before
```lua
if table.find(v,Spellups["AF"]["list"]) then
    --left empty becaue
else
    ...
end
```

### After
```lua
if table.find(v,Spellups["AF"]["list"]) then
    -- spell v is still active on the player; no need to requeue
else
    ...
end
```

## Test plan

- [x] Comment-only change. No behavior is altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)