### PR TITLE
Guard against nil spell entry in affoff recovery check

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -1141,8 +1141,9 @@ function affoff(name,line,wc)
 		end --end for loop
 	end
 
-	if table.find(Spellups["AS"]["list"][sn]["recovery"],Spellups["RT"]["affectedrecovery"]) ~= nil then
-		hadarprint("affected by recovery:"..Spellups["AS"]["list"][sn]["name"].." not recasting","debug")
+	local entry = Spellups["AS"]["list"][sn]
+	if entry and entry["recovery"] and table.find(entry["recovery"],Spellups["RT"]["affectedrecovery"]) ~= nil then
+		hadarprint("affected by recovery:"..entry["name"].." not recasting","debug")
 		return
 	end
 


### PR DESCRIPTION
## Summary

In `SpellupRecast/Hadar_Spellups.xml`, the recovery check inside `affoff()` indexed `Spellups["AS"]["list"][sn]["recovery"]` with no nil guard. If a server `{affoff}` arrives before the slist capture has populated `Spellups["AS"]["list"]` — plugin reload, very early in the session, an interrupted slist — `Spellups["AS"]["list"][sn]` is `nil` and the next `["recovery"]` index throws and breaks the trigger.

This binds the entry once, guards both `entry` and `entry.recovery` before the `table.find` call, and reuses `entry.name` in the debug print so the same race can't crash that line either. Normal-case behavior is unchanged — when slist is loaded, all three checks pass and the original logic runs.

### Before
```lua
if table.find(Spellups["AS"]["list"][sn]["recovery"],Spellups["RT"]["affectedrecovery"]) ~= nil then
    hadarprint("affected by recovery:"..Spellups["AS"]["list"][sn]["name"].." not recasting","debug")
    return
end
```

### After
```lua
local entry = Spellups["AS"]["list"][sn]
if entry and entry["recovery"] and table.find(entry["recovery"],Spellups["RT"]["affectedrecovery"]) ~= nil then
    hadarprint("affected by recovery:"..entry["name"].." not recasting","debug")
    return
end
```

## Test plan

- [x] Static — confirmed `Spellups["AS"]["list"]` is populated only by the slist capture triggers; before that, an early `{affoff}` reaches this line with `Spellups["AS"]["list"][sn] == nil`.
- [x] Defensive guard, no observable behavior change once slist is loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)