### PR TITLE
Document the invmon "float" field

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -1075,6 +1075,10 @@ function testshow(arg)
 	print(gmcp("room.info.zone"))
 end
 
+-- Tracks the non-aura item worn in the floating slot (loc 27).
+-- When auto-aura swaps the user's aura into slot 27 to cast sanctuary,
+-- Spellups["GL"]["float"] remembers what was there before so OnPluginBroadcast
+-- can re-wear it after the cast (see "wear "..Spellups["GL"]["float"]).
 function invmon(nm,ln,wc)
 	if tonumber(wc.action) == 1 and tonumber(wc.loc) == 27 then
 		if tonumber(Spellups["GL"]["auranumber"]) ~= tonumber(wc.id) then


### PR DESCRIPTION
## Summary

`Spellups["GL"]["float"]` is updated by the `invmon` handler in `SpellupRecast/Hadar_Spellups.xml` and consumed by `OnPluginBroadcast` when auto-aura fires, but the variable name doesn't say what role it plays. This adds a four-line comment above the function describing the round-trip: `invmon` remembers whatever non-aura item the user normally wears in the floating slot (loc 27) so the broadcast handler can re-wear it after the aura swap (`"wear "..Spellups["GL"]["float"]`).

Comment-only; no behavior change.

### Before
```lua
function invmon(nm,ln,wc)
    if tonumber(wc.action) == 1 and tonumber(wc.loc) == 27 then
        if tonumber(Spellups["GL"]["auranumber"]) ~= tonumber(wc.id) then
            Spellups["GL"]["float"] = tonumber(wc.id)
        end
    end
end
```

### After
```lua
-- Tracks the non-aura item worn in the floating slot (loc 27).
-- When auto-aura swaps the user's aura into slot 27 to cast sanctuary,
-- Spellups["GL"]["float"] remembers what was there before so OnPluginBroadcast
-- can re-wear it after the cast (see "wear "..Spellups["GL"]["float"]).
function invmon(nm,ln,wc)
    if tonumber(wc.action) == 1 and tonumber(wc.loc) == 27 then
        if tonumber(Spellups["GL"]["auranumber"]) ~= tonumber(wc.id) then
            Spellups["GL"]["float"] = tonumber(wc.id)
        end
    end
end
```

## Test plan

- [x] Comment-only change. No behavior is altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)