### PR TITLE
Stop persisting Spellups on every checkExist call

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -713,17 +713,15 @@ function buildInitial()
     }
 end
 
-function checkExist(tbl, idx, val) 
+function checkExist(tbl, idx, val)
 
      if not Spellups[tbl] then
           Spellups[tbl] = {}
      end
 
      if not Spellups[tbl][idx] then
-               Spellups[tbl][idx] = val
-               SetVariable("Spellups", serialize.save("Spellups")) 
+          Spellups[tbl][idx] = val
      end
-     
 end
 
 function injectVars()


### PR DESCRIPTION
## Summary

`checkExist()` in `SpellupRecast/Hadar_Spellups.xml` ensures a key exists in the `Spellups` table and was also calling `SetVariable("Spellups", serialize.save("Spellups"))` every time it added a missing key. Because `injectVars()` calls `checkExist` dozens of times in sequence on startup, the full `Spellups` table was being serialized and written to plugin state once per key — measurable I/O churn for no benefit on a fresh install or version bump.

This drops the `SetVariable` call. `OnPluginSaveState` already persists `Spellups` (via `serialize.save_simple`) at shutdown, plugin disable, and the standard MUSHclient save points, so the data still reaches disk — just once, at the right time.

As a side effect this also removes the only call to `serialize.save("Spellups")` (the name-based variant), leaving `serialize.save_simple` as the single writer. That matches what the `loadstring` reader in `OnPluginEnable` already expects, so the read/write paths are now consistent.

The over-indented assignment inside the `if` branch is also tidied.

### Before
```lua
function checkExist(tbl, idx, val) 

     if not Spellups[tbl] then
          Spellups[tbl] = {}
     end

     if not Spellups[tbl][idx] then
               Spellups[tbl][idx] = val
               SetVariable("Spellups", serialize.save("Spellups")) 
     end
     
end
```

### After
```lua
function checkExist(tbl, idx, val)

     if not Spellups[tbl] then
          Spellups[tbl] = {}
     end

     if not Spellups[tbl][idx] then
          Spellups[tbl][idx] = val
     end
end
```

## Test plan

- [x] Static — confirmed `OnPluginSaveState` (line 544) is the canonical writer; `checkExist`'s SetVariable was redundant.
- [x] No normal-flow behavior change — keys are still ensured to exist; persistence still happens, just at the right granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)