### PR TITLE
Use gmcp helper in OnPluginBroadcast

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -473,12 +473,8 @@ end
 function OnPluginBroadcast(msg, id, name, text)
 	if id == "3e7dedbe37e44942dd46d264" then -- message from the GMCP Handler
 		if (text == "char.status") then
+			currentState = tonumber(gmcp("char.status.state"))
 
-               res, gmcparg = CallPlugin("3e7dedbe37e44942dd46d264","gmcpval","char")
-               luastmt = "gmcpdata = " .. gmcparg
-               assert (loadstring (luastmt or "")) ()
-               currentState = tonumber(gmcpval("status.state"))
-			
 			if currentState == 3 and Spellups["GL"]["autoaura"] == "yes" and Spellups["GL"]["autoaurafired"] == "no" then
 				hadarprint("Should be wearing eqipment "..Spellups["GL"]["float"],"debug")
 				Spellups["GL"]["autoaurafired"] = "yes"
@@ -492,21 +488,13 @@ function OnPluginBroadcast(msg, id, name, text)
 			SendSlistCommand()
 		end	
 		if (text == "char.vitals") then
-			res, gmcparg = CallPlugin("3e7dedbe37e44942dd46d264","gmcpval","char")
-            luastmt = "gmcpdata = " .. gmcparg
-            assert (loadstring (luastmt or "")) ()
-			
-			currentmana = tonumber(gmcpval("vitals.mana"))
+			currentmana = tonumber(gmcp("char.vitals.mana"))
 			if type(currentmana) ~= "number" then
 				currentmana = 0
 			end
 		end
 		if (text == "char.maxstats") then
-			res, gmcparg = CallPlugin("3e7dedbe37e44942dd46d264","gmcpval","char")
-            luastmt = "gmcpdata = " .. gmcparg
-            assert (loadstring (luastmt or "")) ()
-			
-			maxmana = tonumber(gmcpval("maxstats.maxmana"))
+			maxmana = tonumber(gmcp("char.maxstats.maxmana"))
 			if maxmana == nil or maxmana == -1 then
 				Spellups["EX"]["percentageStop"] = 0
 			else
@@ -522,9 +510,9 @@ function OnPluginBroadcast(msg, id, name, text)
 			else
 				return
 			end
-			maxmana = tonumber(gmcpval("maxstats.maxmana"))
+			maxmana = tonumber(gmcp("char.maxstats.maxmana"))
 			local percentage = (maxmana*Spellups["GL"]["percEnable"]/100)
-			currentmana = tonumber(gmcpval("vitals.mana"))
+			currentmana = tonumber(gmcp("char.vitals.mana"))
 			if currentmana >= percentage then
 				if Spellups["GL"]["DisabledReason"] == "died2" then
 					hadarprint("trying to recast","debug")


### PR DESCRIPTION
## Summary

`OnPluginBroadcast` in `SpellupRecast/Hadar_Spellups.xml` had four sites that each manually performed the `CallPlugin → loadstring("gmcpdata = ..") → gmcpval(...)` pattern just to read a single GMCP field. The `gmcp()` helper from `gmcphelper` — already `require`d at the top of the script and already used elsewhere in this plugin — wraps exactly that pattern and returns the value directly.

This converts each pair to the equivalent direct `gmcp()` call:

| Before | After |
|---|---|
| `CallPlugin/loadstring/gmcpval("status.state")` | `gmcp("char.status.state")` |
| `CallPlugin/loadstring/gmcpval("vitals.mana")` | `gmcp("char.vitals.mana")` |
| `CallPlugin/loadstring/gmcpval("maxstats.maxmana")` | `gmcp("char.maxstats.maxmana")` |

The two bare `gmcpval(...)` calls in the `SpellsDisabled` branch had been relying on whatever `gmcpdata` the most recent inline `loadstring` happened to populate. Those are converted to direct `gmcp()` calls too, so they stop depending on the side-effect.

No behavior change — `gmcp()` internally does the same `CallPlugin` round-trip to `aard_GMCP_handler`. The change removes ~16 lines of duplicated boilerplate from the hot path that runs on every GMCP broadcast.

## Test plan

- [x] Reload plugin, exercise `char.status` / `char.vitals` / `char.maxstats` broadcasts in MUSHclient (movement, damage, regen). Verified by author.
- [x] Confirm spellups still recast on `{affoff}` after the change. Verified by author.
- [x] Confirm `hsp debug` output for vitals/maxstats values is unchanged. Verified by author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)