### PR TITLE
Add safety timeout for slist capture

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -914,13 +914,27 @@ function SendSlistCommand()
 		EnableTrigger("HSPRecoveriesStart", true)
 		hadarprint("***Getting Skills/Spells","script")
 		SendNoEcho("slist hsp")
+		-- If slist output is interrupted (lag, link flap, conflict with
+		-- another plugin), HSP_stop_sList may never fire and the capture
+		-- gate stays locked. Schedule a 10-second safety reset so a future
+		-- broadcast can retry the request.
+		check(AddTimer("HSPslistSafety", 0, 0, 10, "", timer_flag.Enabled+timer_flag.OneShot+timer_flag.Replace, "HSP_slist_safety_reset"))
 	end
 end
 
 function HSP_stop_sList()
 		EnableTriggerGroup("HSPslistCapture", false)
+		DeleteTimer("HSPslistSafety")
 		SaveState()
 		hadarprint("***Got all skills/spells","script")
+end
+
+function HSP_slist_safety_reset()
+	if slistCommandSent then
+		hadarprint("slist capture didn't complete in 10s, resetting gate","debug")
+		EnableTriggerGroup("HSPslistCapture", false)
+		slistCommandSent = false
+	end
 end
 
 function SlistUpdate(name, line, wildcards)


### PR DESCRIPTION
## Summary

`SendSlistCommand` in `SpellupRecast/Hadar_Spellups.xml` sets a one-shot gate (`slistCommandSent = true`) when it enables the `HSPslistCapture` trigger group and sends `slist hsp`, expecting `HSP_stop_sList` to fire on the closing `{/spellheaders}` tag and clear the in-progress state. If that closing tag never arrives — heavy lag, link flap, a conflicting plugin that gags the close, an interrupted slist mid-stream — the gate stays locked, the trigger group stays enabled, and the plugin silently never refreshes its spell list for the rest of the session. Three other call sites (`fullspellupreset` and friends) reset the gate manually, but a user who hits an interrupted slist has no way to know that's the cause.

This adds a 10-second safety timer. On normal completion, `HSP_stop_sList` deletes the timer and behavior is unchanged. On interruption, the timer fires, disables the trigger group, and clears the gate so the next `char.status` broadcast can re-request slist.

### Diff overview

In `SendSlistCommand`:
```lua
SendNoEcho("slist hsp")
-- If slist output is interrupted (lag, link flap, conflict with
-- another plugin), HSP_stop_sList may never fire and the capture
-- gate stays locked. Schedule a 10-second safety reset so a future
-- broadcast can retry the request.
check(AddTimer("HSPslistSafety", 0, 0, 10, "", timer_flag.Enabled+timer_flag.OneShot+timer_flag.Replace, "HSP_slist_safety_reset"))
```

In `HSP_stop_sList` (cancel on success):
```lua
EnableTriggerGroup("HSPslistCapture", false)
DeleteTimer("HSPslistSafety")
SaveState()
```

New function (only runs on timeout):
```lua
function HSP_slist_safety_reset()
    if slistCommandSent then
        hadarprint("slist capture didn't complete in 10s, resetting gate","debug")
        EnableTriggerGroup("HSPslistCapture", false)
        slistCommandSent = false
    end
end
```

The timer pattern matches the existing `rcwarning` timers in this file (`timer_flag.Enabled+timer_flag.OneShot+timer_flag.Replace` with a script-callback function name).

## Test plan

- [x] Normal flow: reload plugin, trigger an slist (`fullspellupreset` then any `char.status` broadcast). `HSP_stop_sList` fires on `{/spellheaders}`, `DeleteTimer` cancels the safety timer, no debug log line about resetting the gate.
- [x] Behavior under non-interruption is identical to the old version.
- [ ] Interruption flow (hard to reproduce on demand): if a future slist is interrupted, the debug log will print "slist capture didn't complete in 10s, resetting gate" and the next broadcast will retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)