### PR TITLE
Wire up HSPRecoveriesCapture to populate affectedrecovery

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -82,10 +82,11 @@
 <trigger
 	name="HSPRecoveriesCapture"
 	enabled="n"
-	match="^[0-9]+,[^,]+,[0-9]+$"
+	match="^([0-9]+),([^,]+),([0-9]+)$"
 	regexp="y"
 	omit_from_output="y"
 	sequence="100"
+	script="RecoveriesUpdate"
 >
 </trigger>
 <trigger
@@ -981,6 +982,24 @@ function SlistUpdate(name, line, wildcards)
 	end
 		
 end  --end update
+
+-- Parses a single row of the {recoveries hsp} section of slist hsp.
+-- Each row is "<rc>,<name>,<seconds_remaining>". seconds > 0 means the
+-- group is in cooldown; 0 means it isn't. Mirroring the server's view
+-- into Spellups["RT"]["affectedrecovery"] keeps the table in sync on
+-- every slist refresh.
+function RecoveriesUpdate(name, line, wildcards)
+	local rc = tonumber(wildcards[1])
+	local seconds = tonumber(wildcards[3])
+
+	if rc == nil or seconds == nil then return end
+
+	if seconds > 0 then
+		Spellups["RT"]["affectedrecovery"][rc] = seconds
+	else
+		Spellups["RT"]["affectedrecovery"][rc] = nil
+	end
+end
 ----------------------------------------------------------------------------------------------------
 --							  End Standard Template	 				        --
 --														       	  --


### PR DESCRIPTION
## Summary

`HSPRecoveriesCapture` in `SpellupRecast/Hadar_Spellups.xml` fires on every row of the `{recoveries hsp}` sub-section that `slist hsp` emits after the spell list — but the trigger had no capture groups and no `script` attribute, so the rows were silently gagged from output and never parsed. The complete `slist hsp` output looks like:

```
{spellheaders hsp}
... spell rows handled by SlistUpdate ...
{/spellheaders}
{recoveries hsp}
40,Hex,15            <- caught by HSPRecoveriesCapture, then discarded
41,Tempering,0
...
{/recoveries}
```

The `{recoveries hsp}` rows tell us the *current* state of each recovery group from the server's point of view. `Spellups["RT"]["affectedrecovery"]` is supposed to mirror that state, but the only writers were `recon()` / `recoff()` reacting to live events — meaning a plugin reload, fresh install, or any mid-session reconnect inherited stale or missing recovery state until the next live transition.

This PR adds capture groups to the trigger regex, wires it to a new `RecoveriesUpdate` script that writes each row into `affectedrecovery`, and makes the slist refresh the authoritative source for that table.

### Diff overview

Trigger:
```diff
- match="^[0-9]+,[^,]+,[0-9]+$"
+ match="^([0-9]+),([^,]+),([0-9]+)$"
+ script="RecoveriesUpdate"
```

New function next to `SlistUpdate`:
```lua
function RecoveriesUpdate(name, line, wildcards)
    local rc = tonumber(wildcards[1])
    local seconds = tonumber(wildcards[3])

    if rc == nil or seconds == nil then return end

    if seconds > 0 then
        Spellups["RT"]["affectedrecovery"][rc] = seconds
    else
        Spellups["RT"]["affectedrecovery"][rc] = nil
    end
end
```

### Why this matters now

A companion PR ([#103](https://github.com/zzyzzyzzx/Hadar/pull/103)) fixes a crash in `recon`/`recoff` that could leave stale entries in `affectedrecovery` and persist them to disk. Wiring up `RecoveriesUpdate` means that even users who had stale entries from before the crash fix will see their state self-heal on the next slist refresh, instead of needing to manually delete the plugin state file.

It also fixes the long-standing case where a fresh install or reconnect mid-recovery had no way to learn about active recoveries until each one individually ended and `{recoff}` fired.

## Test plan

- [x] Static: confirmed the trigger lifecycle — `HSPRecoveriesStart` enables `Capture` and `End`, `End` disables all three. Adding a script to `Capture` only changes per-row behavior; lifecycle unchanged.
- [x] Static: `wildcards[1]` (rc) and `wildcards[3]` (seconds) are guarded with `tonumber` and nil-checks.
- [ ] In-game: trigger an active recovery (cast any spell with cooldown), wait for `slist hsp` (auto-fires on `char.status`), confirm `affectedrecovery` reflects current server state. Confirm `affoff` for affected spell groups correctly skips recast during cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)