### PR TITLE
Guard SlistUpdate against multi-recovery-group rows

### DIFF
--- a/SpellupRecast/Hadar_Spellups.xml
+++ b/SpellupRecast/Hadar_Spellups.xml
@@ -929,7 +929,11 @@ function SlistUpdate(name, line, wildcards)
 	local tg = tonumber(wildcards[3]) -- target
 	local du = tonumber(wildcards[4]) -- duration
 	local pc = tonumber(wildcards[5]) -- percent practiced
-	local rc = tonumber(wildcards[6]) -- recovery
+	-- Recovery is captured as ([+-]?[0-9,]+) so the regex tolerates multi-
+	-- recovery rows like "3,4". tonumber returns nil on those; coerce to -1
+	-- (the "no recovery" sentinel) so the rc ~= -1 guards below skip the
+	-- RT writes that would otherwise crash on a nil table key.
+	local rc = tonumber(wildcards[6]) or -1 -- recovery
 	local ty = tonumber(wildcards[7]) -- type
 	
 	Spellups["AS"]["list"][sn] = {name = nm,target = tg,duration = du,prac = pc,recovery = rc,type = ty}


### PR DESCRIPTION
## Summary

The `slist hsp` line regex in `SpellupRecast/Hadar_Spellups.xml` captures the recovery field as `([+-]?[0-9,]+)` — the comma in the character class explicitly tolerates multi-recovery rows like `"3,4"` for spells that belong to more than one recovery group. `tonumber` returns `nil` on those, and the subsequent writes inside `SlistUpdate` —

```lua
Spellups["RT"]["allrecoveries"][rc] = {...}
Spellups["RT"][rc]                  = {...}
```

— then attempt a table assignment with a nil key, which raises `table index is nil` and aborts the rest of `SlistUpdate` for that row. The spell ends up missing from `Spellups["AS"]["list"]`, and downstream code (`affoff`, `recon`, `recoff`, `cast_spells`) silently misbehaves for it.

Almost all current Aardwolf spells use a single recovery group, so this is latent rather than actively observed — but the regex was clearly designed to anticipate the multi-recovery case, which means it's a deliberate edge that just isn't handled at the parse step.

### Fix

Coerce a nil `rc` to `-1` (the "no recovery" sentinel already used everywhere else for spells that don't participate in recovery tracking). The existing `if rc ~= -1` guards then skip the RT writes harmlessly. The spell still lands in `Spellups["AS"]["list"]` with `rc = -1`, which just means it doesn't get recovery-group bookkeeping — same treatment as any spell the server marks recovery-less.

### Diff overview

```diff
- local rc = tonumber(wildcards[6]) -- recovery
+ -- Recovery is captured as ([+-]?[0-9,]+) so the regex tolerates multi-
+ -- recovery rows like "3,4". tonumber returns nil on those; coerce to -1
+ -- (the "no recovery" sentinel) so the rc ~= -1 guards below skip the
+ -- RT writes that would otherwise crash on a nil table key.
+ local rc = tonumber(wildcards[6]) or -1 -- recovery
```

## Test plan

- [x] Static: confirmed both writers of `Spellups["RT"][rc]` and `Spellups["RT"]["allrecoveries"][rc]` are gated on `if rc ~= -1`, so `rc = -1` cleanly skips them.
- [x] No-op on the happy path: single-recovery rows go through `tonumber(wildcards[6])` and bypass the `or -1` fallback unchanged.
- [ ] Best-effort runtime verification is hard without a real multi-recovery spell in the player's slist; the change is defensive against a regex case that already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)